### PR TITLE
Remove language from 'other_params'

### DIFF
--- a/src/Helper/ApiHelper.php
+++ b/src/Helper/ApiHelper.php
@@ -71,8 +71,6 @@ class ApiHelper extends AbstractHelper
             $otherParameters['libraries'] = implode(',', $libraries);
         }
 
-        $otherParameters['language'] = $language;
-
         // Google Maps API warning: SensorNotRequired https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required
         $otherParameters['sensor'] = json_encode((bool) $sensor);
 


### PR DESCRIPTION
Browser language will now be used for map locations (e.g.: "Brussels" vs "Bruxelles" vs "Brussel")