### PR TITLE
Fix return type docblock

### DIFF
--- a/src/Base/Coordinate.php
+++ b/src/Base/Coordinate.php
@@ -76,7 +76,7 @@ class Coordinate extends AbstractJavascriptVariableAsset
     /**
      * Gets the longitude
      *
-     * @return doube The longitude.
+     * @return double The longitude.
      */
     public function getLongitude()
     {


### PR DESCRIPTION
Fixed a typo, `doube` has to be `double`